### PR TITLE
Optimize JWT parsing and docs

### DIFF
--- a/benchmark/parse_jwt_header_benchmark.dart
+++ b/benchmark/parse_jwt_header_benchmark.dart
@@ -1,0 +1,19 @@
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:firebase_verify_token_dart/firebase_jwt.dart';
+
+class ParseJwtHeaderBenchmark extends BenchmarkBase {
+  ParseJwtHeaderBenchmark() : super('ParseJwtHeader');
+
+  // Example token with dummy header and payload segments.
+  static const _token =
+      'eyJhbGciOiJSUzI1NiIsImtpZCI6Ijg5NzY1NCJ9.eyJhdWQiOiJwcm9qZWN0SWQiLCJleHAiOjE2MDAwMDAwMDB9.signature';
+
+  @override
+  void run() {
+    FirebaseJWT.parseJwtHeader(_token);
+  }
+}
+
+void main() {
+  ParseJwtHeaderBenchmark().report();
+}

--- a/lib/firebase_jwt.dart
+++ b/lib/firebase_jwt.dart
@@ -1,37 +1,35 @@
 import 'dart:convert';
 
-///
+/// Utilities for decoding segments of Firebase JWT tokens.
 class FirebaseJWT {
-  /// This method it's used to get a payload data by a firebase jwt token
+  /// Parses the header segment of a Firebase JWT [token] and returns its values.
+  ///
+  /// Throws an [Exception] if the token does not have exactly three parts or if
+  /// the decoded header cannot be represented as a [Map] of string keys. Throws
+  /// a [FormatException] if the header segment is not valid Base64URL.
   static Map<String, dynamic> parseJwtHeader(String token) {
-    final parts = token.split('.');
-    if (parts.length != 3) {
+    final firstDot = token.indexOf('.');
+    final secondDot = token.indexOf('.', firstDot + 1);
+    if (firstDot == -1 ||
+        secondDot == -1 ||
+        token.indexOf('.', secondDot + 1) != -1) {
       throw Exception('invalid token');
     }
 
-    final payload = _decodeBase64(parts[0]);
-    final payloadMap = json.decode(payload);
-    if (payloadMap is! Map<String, dynamic>) {
+    final decoded = _decodeBase64(token.substring(0, firstDot));
+    final headerMap = json.decode(decoded);
+    if (headerMap is! Map<String, dynamic>) {
       throw Exception('invalid payload');
     }
 
-    return payloadMap;
+    return headerMap;
   }
 
+  /// Decodes a Base64URL-encoded [str] into a UTF-8 string.
+  ///
+  /// Throws a [FormatException] if [str] is not properly Base64URL encoded.
   static String _decodeBase64(String str) {
-    var output = str.replaceAll('-', '+').replaceAll('_', '/');
-
-    switch (output.length % 4) {
-      case 0:
-        break;
-      case 2:
-        output += '==';
-      case 3:
-        output += '=';
-      default:
-        throw Exception('Illegal base64url string!"');
-    }
-
-    return utf8.decode(base64Url.decode(output));
+    final normalized = base64Url.normalize(str);
+    return utf8.decode(base64Url.decode(normalized));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,6 @@ dependencies:
 
 dev_dependencies:
   very_good_analysis: ^7.0.0
+  benchmark_harness: ^2.2.0
 
 


### PR DESCRIPTION
## Summary
- streamline JWT header parsing and base64 decoding
- reduce key validation allocations and precompile cache-control regex
- document FirebaseJWT utilities and add benchmark harness
- clarify potential Base64URL `FormatException` in JWT header parsing

## Testing
- `dart pub get` *(fails: command not found: dart)*
- `dart format .` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `dart run benchmark/parse_jwt_header_benchmark.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689a60f74754832ca65526f78af620dc